### PR TITLE
Adding Accounts System

### DIFF
--- a/applicationdomainproject/package-lock.json
+++ b/applicationdomainproject/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.0.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -1430,6 +1431,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1943,6 +1950,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2929,6 +2945,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.3.0.tgz",
+      "integrity": "sha512-466f2W7HIWaNXTKM5nHTqNxLrHTyXybm7R0eBlVSt0k/u55tTCDO194OIx/NrYD4TS5SXKTNekXfT37kMKUjgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.3.0.tgz",
+      "integrity": "sha512-z7Q5FTiHGgQfEurX/FBinkOXhWREJIAB2RiU24lvcBa82PxUpwqvs/PAXb9lJyPjTs2jrl6UkLvCZVGJPeNuuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3032,6 +3088,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3122,6 +3184,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/applicationdomainproject/package.json
+++ b/applicationdomainproject/package.json
@@ -10,9 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@supabase/supabase-js": "^2.0.0"
+    "react-router-dom": "^7.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/applicationdomainproject/src/AccountView.tsx
+++ b/applicationdomainproject/src/AccountView.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { createClient } from "@supabase/supabase-js";
 import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useParams } from "react-router-dom";
 import "./App.css";
+import LoginScreen from "./LoginScreen";
+import Header from "./Header";
 
 const SUPABASE_URL = "https://tfgesyyngnxrvzckszfy.supabase.co";
 const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRmZ2VzeXluZ254cnZ6Y2tzemZ5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mzg4OTc0ODEsImV4cCI6MjA1NDQ3MzQ4MX0.ScqA7yyTMrBjDqegXiuxpqJ9PYAkzAcgw2CEfpNmoT4";
@@ -28,6 +30,8 @@ interface Account {
 }
 
 const AccountTable = () => {
+    const [isLoggedIn, setIsLoggedIn] = useState<boolean>(true);
+
     const [accounts, setAccounts] = useState<Account[]>([]);
 
     useEffect(() => {
@@ -41,9 +45,14 @@ const AccountTable = () => {
         };
         fetchAccounts();
     }, []);
+    const handleLogout = () => setIsLoggedIn(false);
+
+    if (!isLoggedIn) return <LoginScreen />;
 
     return (
         <div className="container">
+            <Header label="Admin Panel" logout={handleLogout} />
+
             <h1>Accounts</h1>
             <table>
                 <thead>

--- a/applicationdomainproject/src/AccountView.tsx
+++ b/applicationdomainproject/src/AccountView.tsx
@@ -117,8 +117,9 @@ const AccountDetail = () => {
     return (
         <div className="container">
             <h1>Account Details</h1>
+
             {Object.entries(account).map(([key, value]) => (
-                <p key={key}><strong>{key.charAt(0).toUpperCase() + key.slice(1)}:</strong> {String(value)}</p>
+                <p key={key}>{key.charAt(0).toUpperCase() + key.slice(1)}: {String(value)}</p>
             ))}
             <button onClick={() => navigate(-1)} className="view-button">Back to Accounts</button>
         </div>

--- a/applicationdomainproject/src/AccountView.tsx
+++ b/applicationdomainproject/src/AccountView.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { createClient } from "@supabase/supabase-js";
+import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useParams } from "react-router-dom";
+import "./App.css";
+
+const SUPABASE_URL = "https://tfgesyyngnxrvzckszfy.supabase.co";
+const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRmZ2VzeXluZ254cnZ6Y2tzemZ5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mzg4OTc0ODEsImV4cCI6MjA1NDQ3MzQ4MX0.ScqA7yyTMrBjDqegXiuxpqJ9PYAkzAcgw2CEfpNmoT4";
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+interface Account {
+    id: number;
+    date: string;
+    created_at: string;
+    account_name: string;
+    account_number: number;
+    account_description: string;
+    normal_side: number;
+    account_catagory: string;
+    account_subcatagory: string;
+    initial_balance: number;
+    debit: number;
+    credit: number;
+    balance: number;
+    user_id: number;
+    order: string;
+    statement: string;
+    comment: string;
+}
+
+const AccountTable = () => {
+    const [accounts, setAccounts] = useState<Account[]>([]);
+
+    useEffect(() => {
+        const fetchAccounts = async () => {
+            const { data, error } = await supabase.from("Chart_Of_Accounts").select("*");
+            if (error) {
+                console.error("Error fetching accounts:", error);
+            } else {
+                setAccounts(data || []);
+            }
+        };
+        fetchAccounts();
+    }, []);
+
+    return (
+        <div className="container">
+            <h1>Accounts</h1>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Account Name</th>
+                        <th>Account Number</th>
+                        <th>Category</th>
+                        <th>Balance</th>
+                        <th>Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {accounts.map((account) => (
+                        <tr key={account.id}>
+                            <td>{account.account_name}</td>
+                            <td>{account.account_number}</td>
+                            <td>{account.account_catagory}</td>
+                            <td>{account.balance}</td>
+                            <td>
+                                <Link to={`/accounts/${account.id}`} className="view-button">View</Link>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+const AccountDetail = () => {
+    const { id } = useParams<{ id: string }>();
+    const [account, setAccount] = useState<Account | null>(null);
+    const [loading, setLoading] = useState<boolean>(true); // Add loading state
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const fetchAccount = async () => {
+            if (!id) return;
+            const { data, error } = await supabase
+                .from("Chart_Of_Accounts") // Ensure table name is correct
+                .select("*")
+                .eq("id", id)
+                .single();
+
+            if (error) {
+                console.error("Error fetching account:", error);
+                setLoading(false);  // Stop loading if there's an error
+            } else {
+                console.log("Fetched account data:", data);
+                setAccount(data);
+                setLoading(false);  // Stop loading after data is set
+            }
+        };
+        fetchAccount();
+    }, [id]);
+
+    if (loading) {
+        return <p>Loading...</p>;  // Show loading state while data is being fetched
+    }
+
+    if (!account) {
+        return <p>Account not found</p>; // Display if no account found
+    }
+
+    return (
+        <div className="container">
+            <h1>Account Details</h1>
+            {Object.entries(account).map(([key, value]) => (
+                <p key={key}><strong>{key.charAt(0).toUpperCase() + key.slice(1)}:</strong> {String(value)}</p>
+            ))}
+            <button onClick={() => navigate(-1)} className="view-button">Back to Accounts</button>
+        </div>
+    );
+};
+
+const AccountView = () => {
+    return (
+        <Router>
+            <Routes>
+                <Route path="/" element={<AccountTable />} />
+                <Route path="/accounts/:id" element={<AccountDetail />} />
+            </Routes>
+        </Router>
+    );
+};
+
+export default AccountView;
+

--- a/applicationdomainproject/src/AccountView.tsx
+++ b/applicationdomainproject/src/AccountView.tsx
@@ -50,7 +50,10 @@ const AccountTable = () => {
                     <tr>
                         <th>Account Name</th>
                         <th>Account Number</th>
+                        <th>Description</th>
                         <th>Category</th>
+                        <th>Debit</th>
+                        <th>Credit</th>
                         <th>Balance</th>
                         <th>Action</th>
                     </tr>
@@ -60,7 +63,10 @@ const AccountTable = () => {
                         <tr key={account.id}>
                             <td>{account.account_name}</td>
                             <td>{account.account_number}</td>
+                            <td>{account.account_description}</td>
                             <td>{account.account_catagory}</td>
+                            <td>{account.debit}</td>
+                            <td>{account.credit}</td>
                             <td>{account.balance}</td>
                             <td>
                                 <Link to={`/accounts/${account.id}`} className="view-button">View</Link>

--- a/applicationdomainproject/src/App.css
+++ b/applicationdomainproject/src/App.css
@@ -38,7 +38,7 @@
 
 .container {
     padding: 16px;
-    color: #646cffaa;
+    color: #888;
 }
 
 h1 {

--- a/applicationdomainproject/src/App.css
+++ b/applicationdomainproject/src/App.css
@@ -34,3 +34,45 @@
 .subtle-text {
   color: #888;
 }
+/* App.css */
+
+.container {
+    padding: 16px;
+    color: #646cffaa;
+}
+
+h1 {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 16px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid #ccc;
+    margin-top: 8px;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #f0f0f0;
+}
+
+tr:hover {
+    background-color: #f9f9f9;
+}
+
+.view-link {
+    color: #007bff;
+    text-decoration: none;
+}
+
+    .view-link:hover {
+        text-decoration: underline;
+    }

--- a/applicationdomainproject/src/App.tsx
+++ b/applicationdomainproject/src/App.tsx
@@ -1,12 +1,13 @@
 import './App.css'
 import LoginScreen from './LoginScreen.tsx'
+import AccountView from './AccountView.tsx'
 
 function App() {
 
   return (
     <>
       <div>
-        <LoginScreen />
+        <AccountView />
         </div>
     </>
   )

--- a/applicationdomainproject/src/App.tsx
+++ b/applicationdomainproject/src/App.tsx
@@ -1,13 +1,12 @@
 import './App.css'
 import LoginScreen from './LoginScreen.tsx'
-import AccountView from './AccountView.tsx'
 
 function App() {
 
   return (
     <>
       <div>
-        <AccountView />
+        <LoginScreen />
         </div>
     </>
   )

--- a/applicationdomainproject/src/LoginScreen.tsx
+++ b/applicationdomainproject/src/LoginScreen.tsx
@@ -2,8 +2,8 @@
 import { useState, useEffect } from "react";
 import './App.css';
 import './index.css';
-import AdminPanel from "./AdminPanel";
 import AdminHub from "./AdminHub";
+import AccountView from './AccountView.tsx'
 
 import BaseUser from "./User/BaseUser";
 import Header from "./Header";
@@ -16,6 +16,8 @@ export default function LoginScreen() {
     const [error, setError] = useState("");
     const [showPassword, setShowPassword] = useState(false);
     const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [isAdmin, setIsAdmin] = useState(false);
+
     const [serverStatus, setServerStatus] = useState<"Connected" | "Disconnected" | "Checking...">("Checking...");
 
     const {
@@ -65,6 +67,9 @@ export default function LoginScreen() {
             }
             if (potentialUser.is_active) {
                 setIsLoggedIn(true);
+                if (potentialUser.role == "admin") {
+                    setIsAdmin(true);
+                }
             }
             else setError("User is deactivated");
         } else {
@@ -73,15 +78,18 @@ export default function LoginScreen() {
     };
 
     if (isLoggedIn) {
-        console.log("Logging in to ADMIN");
-        return <AdminHub />;
+        if (isAdmin) {
+            console.log("Logging in to ADMIN");
+            return <AdminHub />;
+        }
+        return <AccountView />;
     }
 
-    return (
+    return ( 
         <section>
             <Header label="Login" />
             <h1>Owlight Financials</h1>
-            <p>
+            <p> 
                 <h4>Username</h4>
                 <input
                     type="text"


### PR DESCRIPTION
**Description**
This pull request adds accounts and account viewing to the system.
When logging in, an admin user will be directed to the Admin Hub, all other users will be directed to the Account View screen.
- Accounts are in the Chart_Of_Accounts table in the database.
  - Admin will be able to create new accounts (this is to be added in the future)
- Accounts are displayed in a table
- Clicking the 'view' button in the table will show a detailed view of the account

**Files Changed**
- AccountView
  - Added this, this file manages accounts and displaying account information.
- LoginScreen
  - Made changes to the login logic, this way users and managers will go to the account screen and the admin users will go to the admin hub screen

**Test Steps**
1. Login as admin
2. confirm that admin hub loads
3. logout
4. login as a user or manager
5. Confirm that an account view screen is shown
6. See that the table is populated, there should be only one entry at this time
7. Click the view button
8. Confirm that the account details are shown